### PR TITLE
ローカルから叩くCLIを作成

### DIFF
--- a/app/flag.go
+++ b/app/flag.go
@@ -16,7 +16,7 @@ func NewFlag() (*Flags, error) {
 	flag.Parse()
 
 	if *url == "" {
-		return nil, fmt.Errorf("URL is required")
+		return nil, fmt.Errorf("url is required")
 	}
 
 	if *number == 0 {

--- a/cmd/bookmarks-local/main.go
+++ b/cmd/bookmarks-local/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/hxrxchang/bookmarks-in-issues/app"
+)
+
+// GitHub Actionsからアクセスできないページ用の、ローカルで動かすCLI
+// gh (GitHub CLI) をインストールして、gh auth login で認証しておく
+func main() {
+	url := flag.String("url", "", "URL")
+	flag.Parse()
+
+	if *url == "" {
+		log.Fatal("url is required")
+	}
+
+	title, err := app.FetchTitle(*url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := createGitHubIssue(title, *url); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Issue created successfully")
+}
+
+func createGitHubIssue(title, description string) error {
+	cmd := exec.Command("gh", "issue", "create", "--title", title, "--body", description)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/cmd/bookmarks-local/main.go
+++ b/cmd/bookmarks-local/main.go
@@ -31,8 +31,8 @@ func main() {
 	log.Println("Issue created successfully")
 }
 
-func createGitHubIssue(title, description string) error {
-	cmd := exec.Command("gh", "issue", "create", "--title", title, "--body", description)
+func createGitHubIssue(title, body string) error {
+	cmd := exec.Command("gh", "issue", "create", "--title", title, "--body", body)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
atcoderがGitHub Actionsからのリクエストを弾くようになったので、localからURLを指定してコマンド実行で、issueを
- title: ページのtitle
- body: URL

で作成できるようにする。