### PR TITLE
URLではない文字列がタイトルに入った場合、エラーにしない

### DIFF
--- a/app/parse.go
+++ b/app/parse.go
@@ -6,10 +6,10 @@ import (
 	"github.com/gocolly/colly/v2"
 )
 
-
 type InvalidUrlError struct {
 	URL string
 }
+
 func (e *InvalidUrlError) Error() string {
 	return e.URL + " is invalid URL"
 }

--- a/app/parse.go
+++ b/app/parse.go
@@ -1,6 +1,26 @@
 package app
 
-import "github.com/gocolly/colly/v2"
+import (
+	"net/url"
+
+	"github.com/gocolly/colly/v2"
+)
+
+
+type InvalidUrlError struct {
+	URL string
+}
+func (e *InvalidUrlError) Error() string {
+	return e.URL + " is invalid URL"
+}
+
+func IsValidUrl(URL string) error {
+	parsedURL, err := url.Parse(URL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return &InvalidUrlError{URL: URL}
+	}
+	return nil
+}
 
 func FetchTitle(URL string) (string, error) {
 	c := colly.NewCollector()

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 
 	"github.com/hxrxchang/bookmarks-in-issues/app"
@@ -8,6 +9,12 @@ import (
 
 func main() {
 	if err := app.Run(); err != nil {
-		log.Fatal(err)
+		var invalidUrlError *app.InvalidUrlError
+		if errors.As(err, &invalidUrlError) {
+			// 正常終了させる
+			log.Panicln(err)
+		} else {
+			log.Fatalln(err)
+		}
 	}
 }


### PR DESCRIPTION
https://github.com/hxrxchang/atcoder/actions/runs/13077955048/job/36494625835#step:2:95
みたいにURLではない文字列がタイトルに入った場合にexit 1するとメールとか来てうざいのでexit 0にする。